### PR TITLE
Enable choosing which plugins to build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,10 @@ plugins: libs
 	$(MAKE) all -C plugins/Nekobi
 
 modguis: plugins
+ifeq ($(BUILD_LV2),true)
 	cp -r modguis/Nekobi.modgui/modgui bin/Nekobi.lv2/
 	cp modguis/Nekobi.modgui/manifest.ttl bin/Nekobi.lv2/modgui.ttl
+endif
 
 gen: plugins dpf/utils/lv2_ttl_generator
 	@$(CURDIR)/dpf/utils/generate-ttl.sh

--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,10 @@ plugins: libs
 
 modguis: plugins
 ifeq ($(BUILD_LV2),true)
+ifeq ($(HAVE_DGL),true)
 	cp -r modguis/Nekobi.modgui/modgui bin/Nekobi.lv2/
 	cp modguis/Nekobi.modgui/manifest.ttl bin/Nekobi.lv2/modgui.ttl
+endif
 endif
 
 gen: plugins dpf/utils/lv2_ttl_generator

--- a/Makefile.mk
+++ b/Makefile.mk
@@ -79,6 +79,10 @@ LINK_FLAGS      = $(LINK_OPTS) $(LDFLAGS)
 endif
 
 # --------------------------------------------------------------
+# Set desired items to build
+BUILD_DSSI      = true
+
+# --------------------------------------------------------------
 # Check for optional libs
 
 ifeq ($(LINUX),true)

--- a/Makefile.mk
+++ b/Makefile.mk
@@ -80,7 +80,8 @@ endif
 
 # --------------------------------------------------------------
 # Set desired items to build
-BUILD_DSSI      = true
+BUILD_DSSI     = true
+BUILD_LV2      = true
 BUILD_VST      = true
 
 # --------------------------------------------------------------

--- a/Makefile.mk
+++ b/Makefile.mk
@@ -81,6 +81,7 @@ endif
 # --------------------------------------------------------------
 # Set desired items to build
 BUILD_DSSI      = true
+BUILD_VST      = true
 
 # --------------------------------------------------------------
 # Check for optional libs

--- a/plugins/Nekobi/DistrhoPluginInfo.h
+++ b/plugins/Nekobi/DistrhoPluginInfo.h
@@ -22,11 +22,14 @@
 #define DISTRHO_PLUGIN_NAME  "Nekobi"
 #define DISTRHO_PLUGIN_URI   "http://distrho.sf.net/plugins/Nekobi"
 
-#define DISTRHO_PLUGIN_HAS_UI        1
 #define DISTRHO_PLUGIN_IS_RT_SAFE    1
 #define DISTRHO_PLUGIN_IS_SYNTH      1
 #define DISTRHO_PLUGIN_NUM_INPUTS    0
 #define DISTRHO_PLUGIN_NUM_OUTPUTS   1
+
+#ifdef HAVE_DGL
+#define DISTRHO_PLUGIN_HAS_UI        1
 #define DISTRHO_PLUGIN_USES_MODGUI   1
+#endif
 
 #endif // DISTRHO_PLUGIN_INFO_H_INCLUDED

--- a/plugins/Nekobi/Makefile
+++ b/plugins/Nekobi/Makefile
@@ -33,11 +33,13 @@ TARGETS += jack
 endif
 endif
 
+ifeq ($(BUILD_DSSI),true)
 ifeq ($(LINUX),true)
 TARGETS += dssi_dsp
 ifeq ($(HAVE_DGL),true)
 ifeq ($(HAVE_LIBLO),true)
 TARGETS += dssi_ui
+endif
 endif
 endif
 endif

--- a/plugins/Nekobi/Makefile
+++ b/plugins/Nekobi/Makefile
@@ -44,10 +44,12 @@ endif
 endif
 endif
 
+ifeq ($(BUILD_LV2),true)
 ifeq ($(HAVE_DGL),true)
 TARGETS += lv2_sep
 else
 TARGETS += lv2_dsp
+endif
 endif
 
 ifeq ($(BUILD_VST),true)

--- a/plugins/Nekobi/Makefile
+++ b/plugins/Nekobi/Makefile
@@ -50,7 +50,9 @@ else
 TARGETS += lv2_dsp
 endif
 
+ifeq ($(BUILD_VST),true)
 TARGETS += vst
+endif
 
 all: $(TARGETS)
 


### PR DESCRIPTION
The Makefile(s) for Nekobi didn't allow one to choose which plugins to build.
This PR adds separate `BUILD_` variables that allow one to choose which plugins to build. They all default to `true`, so nothing has changed for users who don't care about this.
I'd like to do the same for the standalone binary build, but it seems like that would need a couple more changes.

I ran into a failure case when building the LV2 plugin without X11/DGL, it would still signal to a plugin host that a GUI was available which then wouldn't work caused by the modgui files being present.
So I added an additional check if DGL/X11 is present before copying the modgui files.
Note that the `Nekobi.lv2/manifest.ttl` still contains a reference to `modgui.ttl`. I haven't found a way to fix that, it seems to be created by the `generate-ttl.sh` script from dpf.