### PR TITLE
Fix SysEx events causing an infinite loop

### DIFF
--- a/plugins/Nekobi/DistrhoPluginNekobi.cpp
+++ b/plugins/Nekobi/DistrhoPluginNekobi.cpp
@@ -375,9 +375,6 @@ void DistrhoPluginNekobi::run(const float**, float** outputs, uint32_t frames, c
         /* process any ready events */
         while (curEventIndex < midiEventCount && framesDone == midiEvents[curEventIndex].frame)
         {
-            if (midiEvents[curEventIndex].size > MidiEvent::kDataSize)
-                continue;
-
             nekobee_handle_raw_event(&fSynth, midiEvents[curEventIndex].size, midiEvents[curEventIndex].data);
             curEventIndex++;
         }


### PR DESCRIPTION
I investigated the cause of #9 after running into the same issue myself and found that it enters an infinite loop when handling events bigger than 4 bytes, such as the 12 byte SysEx events my midi controller emits whenever I hit the octave up/down buttons. 

I don't have much experience in writing audio plugins so I'm not sure what [these 2 lines](https://github.com/DISTRHO/Nekobi/blob/555e6c39d9e479584f2ea0da890a3907de6e521e/plugins/Nekobi/DistrhoPluginNekobi.cpp#L378) were intended to do, but since the event size doesn't change, if it's greater than 4 it just keeps looping forever. `nekobee_handle_raw_event` returns without doing anything if the event isn't exactly 3 bytes, so removing that if statement causes the event to be skipped and fixes the issue.