### PR TITLE
MS Toolchain; Tuning Knob

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@
 
 bin/
 build/
+
+.vs/
+out/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,3 @@
+cmake_minimum_required(VERSION 3.11)
+add_subdirectory(dpf)
+add_subdirectory(plugins/Nekobi)

--- a/plugins/Nekobi/CMakeLists.txt
+++ b/plugins/Nekobi/CMakeLists.txt
@@ -1,0 +1,13 @@
+DPF_ADD_PLUGIN(Nekobi
+  TARGETS vst2
+  FILES_DSP
+      DistrhoPluginNekobi.cpp
+  FILES_UI
+      DistrhoArtworkNekobi.cpp
+      DistrhoUINekobi.cpp)
+
+target_include_directories(Nekobi PUBLIC 
+    "."
+    "nekobee-src"
+    "artwork"
+)

--- a/plugins/Nekobi/CMakeLists.txt
+++ b/plugins/Nekobi/CMakeLists.txt
@@ -9,5 +9,4 @@ DPF_ADD_PLUGIN(Nekobi
 target_include_directories(Nekobi PUBLIC 
     "."
     "nekobee-src"
-    "artwork"
 )

--- a/plugins/Nekobi/DistrhoPluginNekobi.cpp
+++ b/plugins/Nekobi/DistrhoPluginNekobi.cpp
@@ -46,7 +46,7 @@ bool dssp_voicelist_mutex_trylock(nekobee_synth_t* const synth)
     return true;
 }
 
-bool dssp_voicelist_mutex_unlock(nekobee_synth_t* const synth)
+void dssp_voicelist_mutex_unlock(nekobee_synth_t* const synth)
 {
     synth->voicelist_mutex.unlock();
 }

--- a/plugins/Nekobi/DistrhoPluginNekobi.cpp
+++ b/plugins/Nekobi/DistrhoPluginNekobi.cpp
@@ -296,7 +296,7 @@ void DistrhoPluginNekobi::setParameterValue(uint32_t index, float value)
         break;
     case paramTuning:
         fParams.tuning = value;
-        fSynth.tuning = (value+12.0f)/24.0f * 1.5 + 0.5f; // FIXME: log?
+        fSynth.tuning = exp2f( value / 12.0f );
         DISTRHO_SAFE_ASSERT(fSynth.tuning >= 0.5f && fSynth.tuning <= 2.0f);
         break;
     case paramCutoff:

--- a/plugins/Nekobi/DistrhoPluginNekobi.cpp
+++ b/plugins/Nekobi/DistrhoPluginNekobi.cpp
@@ -18,7 +18,6 @@
 
 #include "DistrhoPluginNekobi.hpp"
 
-extern "C" {
 
 #include "nekobee-src/nekobee_synth.c"
 #include "nekobee-src/nekobee_voice.c"
@@ -31,7 +30,7 @@ extern "C" {
 bool dssp_voicelist_mutex_trylock(nekobee_synth_t* const synth)
 {
     /* Attempt the mutex lock */
-    if (pthread_mutex_trylock(&synth->voicelist_mutex) != 0)
+    if (!synth->voicelist_mutex.try_lock())
     {
         synth->voicelist_mutex_grab_failed = 1;
         return false;
@@ -49,7 +48,7 @@ bool dssp_voicelist_mutex_trylock(nekobee_synth_t* const synth)
 
 bool dssp_voicelist_mutex_unlock(nekobee_synth_t* const synth)
 {
-    return (pthread_mutex_unlock(&synth->voicelist_mutex) == 0);
+    synth->voicelist_mutex.unlock();
 }
 
 // -----------------------------------------------------------------------
@@ -79,7 +78,6 @@ void nekobee_handle_raw_event(nekobee_synth_t* const synth, const uint8_t size, 
     }
 }
 
-} /* extern "C" */
 
 START_NAMESPACE_DISTRHO
 
@@ -109,7 +107,6 @@ DistrhoPluginNekobi::DistrhoPluginNekobi()
 
     fSynth.voice = nekobee_voice_new();
     fSynth.voicelist_mutex_grab_failed = 0;
-    pthread_mutex_init(&fSynth.voicelist_mutex, nullptr);
 
     fSynth.channel_pressure = 0;
     fSynth.pitch_wheel_sensitivity = 0;

--- a/plugins/Nekobi/DistrhoPluginNekobi.hpp
+++ b/plugins/Nekobi/DistrhoPluginNekobi.hpp
@@ -21,9 +21,7 @@
 
 #include "DistrhoPlugin.hpp"
 
-extern "C" {
 #include "nekobee-src/nekobee_synth.h"
-}
 
 START_NAMESPACE_DISTRHO
 

--- a/plugins/Nekobi/nekobee-src/nekobee.h
+++ b/plugins/Nekobi/nekobee-src/nekobee.h
@@ -63,8 +63,8 @@
 
 #else  /* !XSYNTH_DEBUG */
 
-#define XDB_MESSAGE(type, fmt...)
-#define GDB_MESSAGE(type, fmt...)
+#define XDB_MESSAGE(type, fmt, ...)
+#define GDB_MESSAGE(type, fmt, ...)
 #define XSYNTH_DEBUG_INIT(x)
 
 #endif  /* XSYNTH_DEBUG */

--- a/plugins/Nekobi/nekobee-src/nekobee_synth.c
+++ b/plugins/Nekobi/nekobee-src/nekobee_synth.c
@@ -29,7 +29,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <math.h>
-#include <pthread.h>
+#include <mutex>
 
 #include "nekobee.h"
 #include "nekobee_synth.h"

--- a/plugins/Nekobi/nekobee-src/nekobee_synth.h
+++ b/plugins/Nekobi/nekobee-src/nekobee_synth.h
@@ -26,7 +26,7 @@
 #ifndef _XSYNTH_SYNTH_H
 #define _XSYNTH_SYNTH_H
 
-#include <pthread.h>
+#include <mutex>
 
 #include "nekobee.h"
 #include "nekobee_types.h"
@@ -64,7 +64,7 @@ struct _nekobee_synth_t {
 
     //nekobee_voice_t *voice[XSYNTH_MAX_POLYPHONY];
     nekobee_voice_t *voice;
-    pthread_mutex_t voicelist_mutex;
+    std::mutex      voicelist_mutex;
     int             voicelist_mutex_grab_failed;
 
     /* current non-paramter-mapped controller values */


### PR DESCRIPTION
Replaces POSIX-only mutices with std::mutex.
Added CMakeLists to allow building (at least) on Windows with MS build tools.
Finally, changes the behaviour of the tuning parameter in DistrhoPluginNekobi::setParameterValue, which fixes #15.